### PR TITLE
Add .mipmap_size()

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
         pip install mypy
     - name: mypy
       run: mypy --show-column-numbers --hide-error-context .
+    - name: Unit Tests
+      run: python3 -m unittest
 
   build_wheel:
     name: Build wheel

--- a/n64img/image.py
+++ b/n64img/image.py
@@ -15,6 +15,7 @@ class Image:
         self.data: bytes = data
         self.width: int = width
         self.height: int = height
+        self.depth: int = 1
         self.greyscale: bool = False
         self.alpha: bool = False
         self.flip_h: bool = False
@@ -53,24 +54,38 @@ class Image:
             pixels = self.parse()
             self.get_writer().write_array(f, pixels)
 
+    def mipmap_size(self) -> int:
+        size = 0
+        width = self.width
+        while width > 0:
+            # NOTE: rows must be padded to 8-byte boundary
+            row = height = width
+            remainder = ceil(width * self.depth) % 8
+            if remainder != 0:
+                row += ceil((8 - remainder) / self.depth)
+            size += row * height * self.depth
+            width >>= 1
+        return size
+
     def size(self) -> int:
-        return self.width * self.height
+        return ceil(self.width * self.height * self.depth)
 
 
 class CI4(Image):
+    def __init__(self, data, width, height):
+        super().__init__(data, width, height)
+        self.depth = 0.5
+
     def parse(self) -> bytes:
         img = bytearray()
 
         for x, y, i in iter.iter_image_indexes(
-            self.width, self.height, 0.5, self.flip_h, self.flip_v
+            self.width, self.height, self.depth, self.flip_h, self.flip_v
         ):
             img.append(self.data[i] >> 4)
             img.append(self.data[i] & 0xF)
 
         return bytes(img)
-
-    def size(self) -> int:
-        return ceil(self.width * self.height / 2)
 
 
 class CI8(Image):
@@ -82,6 +97,7 @@ class CI8(Image):
 class I1(Image):
     def __init__(self, data, width, height):
         super().__init__(data, width, height)
+        self.depth = 0.125
         self.greyscale = True
 
     def parse(self) -> bytes:
@@ -97,7 +113,6 @@ class I1(Image):
             for j in range(8, 0, -1):
                 # Store the value of each bit as a pixel.
                 p = (b >> (j - 1)) & 0x1
-
                 # Convert active bits to RGB white and inactive to black.
                 p = ceil(0xFF * p)
 
@@ -105,20 +120,18 @@ class I1(Image):
 
         return bytes(img)
 
-    def size(self) -> int:
-        return ceil(self.width * self.height / 8)
-
 
 class I4(Image):
     def __init__(self, data, width, height):
         super().__init__(data, width, height)
+        self.depth = 0.5
         self.greyscale = True
 
     def parse(self) -> bytes:
         img = bytearray()
 
         for x, y, i in iter.iter_image_indexes(
-            self.width, self.height, 0.5, self.flip_h, self.flip_v
+            self.width, self.height, self.depth, self.flip_h, self.flip_v
         ):
             b = self.data[i]
 
@@ -132,9 +145,6 @@ class I4(Image):
 
         return bytes(img)
 
-    def size(self) -> int:
-        return ceil(self.width * self.height / 2)
-
 
 class I8(Image):
     def __init__(self, data, width, height):
@@ -145,6 +155,7 @@ class I8(Image):
 class IA4(Image):
     def __init__(self, data, width, height):
         super().__init__(data, width, height)
+        self.depth = 0.5
         self.greyscale = True
         self.alpha = True
 
@@ -152,7 +163,7 @@ class IA4(Image):
         img = bytearray()
 
         for x, y, i in iter.iter_image_indexes(
-            self.width, self.height, 0.5, flip_h=self.flip_h, flip_v=self.flip_v
+            self.width, self.height, self.depth, flip_h=self.flip_h, flip_v=self.flip_v
         ):
             b = self.data[i]
 
@@ -170,9 +181,6 @@ class IA4(Image):
             img += bytes((i1, a1, i2, a2))
 
         return bytes(img)
-
-    def size(self) -> int:
-        return ceil(self.width * self.height / 2)
 
 
 class IA8(Image):
@@ -203,16 +211,15 @@ class IA8(Image):
 class IA16(Image):
     def __init__(self, data, width, height):
         super().__init__(data, width, height)
+        self.depth = 2
         self.greyscale = True
         self.alpha = True
-
-    def size(self) -> int:
-        return self.width * self.height * 2
 
 
 class RGBA16(Image):
     def __init__(self, data, width, height):
         super().__init__(data, width, height)
+        self.depth = 2
         self.greyscale = False
         self.alpha = True
 
@@ -220,21 +227,16 @@ class RGBA16(Image):
         img = bytearray()
 
         for x, y, i in iter.iter_image_indexes(
-            self.width, self.height, 2, self.flip_h, self.flip_v
+            self.width, self.height, self.depth, self.flip_h, self.flip_v
         ):
             img += bytes(unpack_color(self.data[i:]))
 
         return bytes(img)
 
-    def size(self) -> int:
-        return self.width * self.height * 2
-
 
 class RGBA32(Image):
     def __init__(self, data, width, height):
         super().__init__(data, width, height)
+        self.depth = 4
         self.greyscale = False
         self.alpha = True
-
-    def size(self) -> int:
-        return self.width * self.height * 4

--- a/test/test_image.py
+++ b/test/test_image.py
@@ -1,0 +1,113 @@
+import unittest
+
+from n64img.image import (
+    Image,
+    CI4,
+    CI8,
+    I1,
+    I4,
+    I8,
+    IA4,
+    IA8,
+    IA16,
+    RGBA16,
+    RGBA32,
+)
+
+
+class TestImage(unittest.TestCase):
+    def test_size(self):
+        img = Image(bytes(), 32, 32)
+        self.assertEqual(1024, img.size())
+
+    def test_mipmap_size(self):
+        img = Image(bytes(), 32, 32)
+        # 4x4 needs 4 pixels extra per row; (4+4)*1 = 8
+        # 2x2 needs 6 pixels extra per row; (2+6)*1 = 8
+        # 1x1 needs 7 pixels extra per row; (1+7)*1 = 8
+        # 32*32*1 + 16*16*1 + 8*8*1 + 8*4*1 + 8*2*1 + 8*1*1
+        self.assertEqual(1400, img.mipmap_size())
+
+
+class TestCI4(unittest.TestCase):
+    def test_size(self):
+        img = CI4(bytes(), 32, 32)
+        self.assertEqual(512, img.size())
+
+
+class TestCI8(unittest.TestCase):
+    def test_size(self):
+        img = CI8(bytes(), 32, 32)
+        self.assertEqual(1024, img.size())
+
+
+class TestI1(unittest.TestCase):
+    def test_size(self):
+        img = I1(bytes(), 32, 32)
+        self.assertEqual(128, img.size())
+
+
+class TestI4(unittest.TestCase):
+    def test_size(self):
+        img = I4(bytes(), 32, 32)
+        self.assertEqual(512, img.size())
+
+
+class TestI8(unittest.TestCase):
+    def test_size(self):
+        img = I8(bytes(), 32, 32)
+        self.assertEqual(1024, img.size())
+
+
+class TestIA4(unittest.TestCase):
+    def test_size(self):
+        img = IA4(bytes(), 32, 32)
+        self.assertEqual(512, img.size())
+
+
+class TestIA8(unittest.TestCase):
+    def test_size(self):
+        img = IA8(bytes(), 32, 32)
+        self.assertEqual(1024, img.size())
+
+
+class TestIA16(unittest.TestCase):
+    def test_size(self):
+        img = IA16(bytes(), 32, 32)
+        self.assertEqual(2048, img.size())
+
+
+class TestRGBA16(unittest.TestCase):
+    def test_size(self):
+        img = RGBA16(bytes(), 32, 32)
+        self.assertEqual(2048, img.size())
+
+    def test_mipmap_size(self):
+        img = RGBA16(bytes(), 32, 32)
+        # 2x2 needs 2 pixels extra per row; (2+2)*2 = 8
+        # 1x1 needs 3 pixels extra per row; (1+3)*2 = 8
+        # 32*32*2 + 16*16*2 + 8*8*2 + 4*4*2 + 4*2*2 + 4*1*2
+        self.assertEqual(2744, img.mipmap_size())
+
+
+class TestRGBA32(unittest.TestCase):
+    def test_size(self):
+        img = RGBA32(bytes(), 32, 32)
+        self.assertEqual(4096, img.size())
+
+    def test_mipmap_size(self):
+        img = RGBA32(bytes(), 32, 32)
+        # 1x1 needs 1 pixels extra per row; (1+1)*4 = 8
+        # 32*32*4 + 16*16*4 + 8*8*4 + 4*4*4 + 2*2*4 + 2*1*4
+        self.assertEqual(5464, img.mipmap_size())
+
+    def test_mipmap_size2(self):
+        # TODO: sanity check this
+        img = RGBA32(bytes(), 31, 31)
+        # 31x31 needs 1 pixel extra per row; (31+1)*4 = 128
+        # 15x15 needs 1 pixel extra per row; (15+1)*4 = 64
+        # 7x7 needs 1 pixel extra per row; (7+1)*4 = 32
+        # 3x3 needs 1 pixel extra per row; (3+1)*4 = 16
+        # 1x1 needs 1 pixel extra per row; (1+1)*4 = 8
+        # 32*31*4 + 16*15*4 + 8*7*4 + 4*3*4 + 2*1*4
+        self.assertEqual(5208, img.mipmap_size())


### PR DESCRIPTION
It would be wonderful if someone can sanity check my logic/maths, I was basing it off the example [here](https://www.moria.us/blog/2020/11/n64-part20-tmem-format-and-mip-maps#creating-and-loading-mipmapped-assets). The crucial wording being:

> Creating the mipmapped assets is easy. First, **pad all rows of the texture to 8-byte boundaries**, to match the the padding requirements in TMEM. 

I only have examples of 32x32 RGBA16 mipmapped images in SSSV, and they are indeed `0xAB8` (2744) bytes long.

Whilst this PR isn't hugely useful on it's own, I'm hoping to lean on this functionality to pull out the contiguous mipmapped images I have in the ROM.