### PR TITLE
Revert "Replace ceil in parse functions with hardware-accurate bitwise operations"

### DIFF
--- a/n64img/color.py
+++ b/n64img/color.py
@@ -1,0 +1,16 @@
+from math import ceil
+
+# RRRRRGGG GGBBBBBA
+def unpack_color(data, endianness="big"):
+    s = int.from_bytes(data[0:2], byteorder=endianness)
+
+    r = (s >> 11) & 0x1F
+    g = (s >> 6) & 0x1F
+    b = (s >> 1) & 0x1F
+    a = (s & 1) * 0xFF
+
+    r = ceil(0xFF * (r / 31))
+    g = ceil(0xFF * (g / 31))
+    b = ceil(0xFF * (b / 31))
+
+    return r, g, b, a


### PR DESCRIPTION
Reverts decompals/n64img#2

Reverting for now until we figure out why this is causing failures in PM