### PR TITLE
Add little endian support

### DIFF
--- a/test/test_endian.py
+++ b/test/test_endian.py
@@ -1,0 +1,52 @@
+import unittest
+
+from n64img.image import (
+    CI4,
+    I4,
+    IA4,
+)
+
+
+class TestEndian(unittest.TestCase):
+    def create_4bpp_image(self, t, w, h):
+        data = bytearray((w * h) >> 1)
+        for i in range(0, len(data)):
+            data[i] = i & 0xFF
+
+        return t(data, w, h)
+
+    def test_ci4_endian_big(self):
+        img = self.create_4bpp_image(CI4, 4, 4)
+        pixels = img.parse()
+        self.assertEqual(bytearray([
+            0x00, 0x00, 0x00, 0x01, 0x00, 0x02, 0x00, 0x03,
+            0x00, 0x04, 0x00, 0x05, 0x00, 0x06, 0x00, 0x07,
+        ]), pixels)
+
+    def test_i4_endian_big(self):
+        img = self.create_4bpp_image(I4, 4, 4)
+        pixels = img.parse()
+        print("*****")
+        print(pixels)
+        print("*****")
+        self.assertEqual(bytearray([
+            0x00, 0x00, 0x00, 0x11, 0x00, 0x22, 0x00, 0x33,
+            0x00, 0x44, 0x00, 0x55, 0x00, 0x66, 0x00, 0x77,
+        ]), pixels)
+
+    def test_ia4_endian_big(self):
+        img = self.create_4bpp_image(IA4, 4, 4)
+        pixels = img.parse()
+        print("*****")
+        print(pixels)
+        print("*****")
+        self.assertEqual(bytearray([
+            0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0xFF,
+            0x00, 0x00, 0x24, 0x00,
+            0x00, 0x00, 0x24, 0xFF,
+            0x00, 0x00, 0x49, 0x00,
+            0x00, 0x00, 0x49, 0xFF,
+            0x00, 0x00, 0x6D, 0x00,
+            0x00, 0x00, 0x6D, 0xFF,
+        ]), pixels)

--- a/test/test_endian.py
+++ b/test/test_endian.py
@@ -23,23 +23,35 @@ class TestEndian(unittest.TestCase):
             0x00, 0x04, 0x00, 0x05, 0x00, 0x06, 0x00, 0x07,
         ]), pixels)
 
+    def test_ci4_endian_little(self):
+        img = self.create_4bpp_image(CI4, 4, 4)
+        img.little_endian = True
+        pixels = img.parse()
+        self.assertEqual(bytearray([
+            0x00, 0x00, 0x01, 0x00, 0x02, 0x00, 0x03, 0x00,
+            0x04, 0x00, 0x05, 0x00, 0x06, 0x00, 0x07, 0x00,
+        ]), pixels)
+
     def test_i4_endian_big(self):
         img = self.create_4bpp_image(I4, 4, 4)
         pixels = img.parse()
-        print("*****")
-        print(pixels)
-        print("*****")
         self.assertEqual(bytearray([
             0x00, 0x00, 0x00, 0x11, 0x00, 0x22, 0x00, 0x33,
             0x00, 0x44, 0x00, 0x55, 0x00, 0x66, 0x00, 0x77,
         ]), pixels)
 
+    def test_i4_endian_little(self):
+        img = self.create_4bpp_image(I4, 4, 4)
+        img.little_endian = True
+        pixels = img.parse()
+        self.assertEqual(bytearray([
+            0x00, 0x00, 0x11, 0x00, 0x22, 0x00, 0x33, 0x00,
+            0x44, 0x00, 0x55, 0x00, 0x66, 0x00, 0x77, 0x00,
+        ]), pixels)
+
     def test_ia4_endian_big(self):
         img = self.create_4bpp_image(IA4, 4, 4)
         pixels = img.parse()
-        print("*****")
-        print(pixels)
-        print("*****")
         self.assertEqual(bytearray([
             0x00, 0x00, 0x00, 0x00,
             0x00, 0x00, 0x00, 0xFF,
@@ -49,4 +61,19 @@ class TestEndian(unittest.TestCase):
             0x00, 0x00, 0x49, 0xFF,
             0x00, 0x00, 0x6D, 0x00,
             0x00, 0x00, 0x6D, 0xFF,
+        ]), pixels)
+
+    def test_ia4_endian_little(self):
+        img = self.create_4bpp_image(IA4, 4, 4)
+        img.little_endian = True
+        pixels = img.parse()
+        self.assertEqual(bytearray([
+            0x00, 0x00, 0x00, 0x00,
+            0x00, 0xFF, 0x00, 0x00,
+            0x24, 0x00, 0x00, 0x00,
+            0x24, 0xFF, 0x00, 0x00,
+            0x49, 0x00, 0x00, 0x00,
+            0x49, 0xFF, 0x00, 0x00,
+            0x6D, 0x00, 0x00, 0x00,
+            0x6D, 0xFF, 0x00, 0x00,
         ]), pixels)


### PR DESCRIPTION
## What

4bpp images are swizzled for little endian hardware (eg. PSX) and n64img does not natively handle that:

![image](https://user-images.githubusercontent.com/6128729/227790070-d529e02f-d03c-40f1-b914-d91351630c20.png)

With this PR I am introducing the new class member `little_endian` where, if set to `True`, it will essentially invert the nibbles:

![image](https://user-images.githubusercontent.com/6128729/227790129-be5df2bb-832e-4d52-8c92-97ea4d8fd72a.png)

## How

I added unit tests to ensure the old behaviour remains the same and it is also testing the new one, so we are sure it will not break over time. I am adding just 4bpp support as 8bpp, 16bpp and 32bpp do not have the same problem.

As the for loop for `I4` and `CI4` is relatively small, I decided to take out the `if self.little_endian` so the python interpreter does not check the same value over and over for every pixel. I am not doing the same for `IA4` as it is a bit more complex and the optimisation would be diminished.

## Other approaches

I realise it would be possible to flip the nibbles before passing the data into n64img, but then it would be flipped again by `Image.parse`, effectively introducing unnecessary complexity and transformations that could be avoided.