### PR TITLE
Add preliminary support for word-swap for odd rows

### DIFF
--- a/n64img/image.py
+++ b/n64img/image.py
@@ -20,6 +20,7 @@ class Image:
         self.flip_h: bool = False
         self.flip_v: bool = False
         self.little_endian: bool = False
+        self.swap_words: bool = False
         self.palette: Optional[Palette] = None
 
     def __str__(self) -> str:
@@ -62,13 +63,18 @@ class Image:
         )
 
     def parse(self) -> bytes:
-        if not self.flip_h and not self.flip_v:
+        if not self.flip_h and not self.flip_v and not self.swap_words:
             return self.data
 
         img = bytearray()
 
         for x, y, i in iter.iter_image_indexes(
-            self.width, self.height, self.depth, self.flip_h, self.flip_v
+            self.width,
+            self.height,
+            bytes_per_pixel=self.depth,
+            flip_h=self.flip_h,
+            flip_v=self.flip_v,
+            swap_words=self.swap_words,
         ):
             img.append(self.data[i])
 
@@ -106,13 +112,23 @@ class CI4(Image):
 
         if self.little_endian:
             for x, y, i in iter.iter_image_indexes(
-                self.width, self.height, self.depth, self.flip_h, self.flip_v
+                self.width,
+                self.height,
+                bytes_per_pixel=self.depth,
+                flip_h=self.flip_h,
+                flip_v=self.flip_v,
+                swap_words=self.swap_words,
             ):
                 img.append(self.data[i] & 0xF)
                 img.append(self.data[i] >> 4)
         else:
             for x, y, i in iter.iter_image_indexes(
-                self.width, self.height, self.depth, self.flip_h, self.flip_v
+                self.width,
+                self.height,
+                bytes_per_pixel=self.depth,
+                flip_h=self.flip_h,
+                flip_v=self.flip_v,
+                swap_words=self.swap_words,
             ):
                 img.append(self.data[i] >> 4)
                 img.append(self.data[i] & 0xF)
@@ -164,7 +180,12 @@ class I4(Image):
 
         if self.little_endian:
             for x, y, i in iter.iter_image_indexes(
-                self.width, self.height, self.depth, self.flip_h, self.flip_v
+                self.width,
+                self.height,
+                bytes_per_pixel=self.depth,
+                flip_h=self.flip_h,
+                flip_v=self.flip_v,
+                swap_words=self.swap_words,
             ):
                 b = self.data[i]
 
@@ -177,7 +198,12 @@ class I4(Image):
                 img += bytes((i1, i2))
         else:
             for x, y, i in iter.iter_image_indexes(
-                self.width, self.height, self.depth, self.flip_h, self.flip_v
+                self.width,
+                self.height,
+                bytes_per_pixel=self.depth,
+                flip_h=self.flip_h,
+                flip_v=self.flip_v,
+                swap_words=self.swap_words,
             ):
                 b = self.data[i]
 
@@ -209,7 +235,12 @@ class IA4(Image):
         img = bytearray()
 
         for x, y, i in iter.iter_image_indexes(
-            self.width, self.height, self.depth, flip_h=self.flip_h, flip_v=self.flip_v
+            self.width,
+            self.height,
+            bytes_per_pixel=self.depth,
+            flip_h=self.flip_h,
+            flip_v=self.flip_v,
+            swap_words=self.swap_words,
         ):
             b = self.data[i]
 
@@ -243,7 +274,11 @@ class IA8(Image):
         img = bytearray()
 
         for x, y, i in iter.iter_image_indexes(
-            self.width, self.height, flip_h=self.flip_h, flip_v=self.flip_v
+            self.width,
+            self.height,
+            flip_h=self.flip_h,
+            flip_v=self.flip_v,
+            swap_words=self.swap_words,
         ):
             b = self.data[i]
 
@@ -290,7 +325,12 @@ class RGBA16(Image):
         img = bytearray()
 
         for x, y, i in iter.iter_image_indexes(
-            self.width, self.height, self.depth, self.flip_h, self.flip_v
+            self.width,
+            self.height,
+            bytes_per_pixel=self.depth,
+            flip_h=self.flip_h,
+            flip_v=self.flip_v,
+            swap_words=self.swap_words,
         ):
             s = int.from_bytes(self.data[i : i + 2], byteorder="big")
 

--- a/n64img/iter.py
+++ b/n64img/iter.py
@@ -25,7 +25,7 @@ def iter_image_indexes(
 
     if swap_words:
         xrange_swapped = []
-        pixels_per_word = ceil(WORD_SIZE / bytes_per_pixel)
+        pixels_per_word = ceil(BYTES_PER_WORD / bytes_per_pixel)
         for i in range(0, len(xrange), pixels_per_word * 2):
             xrange_swapped += [
                 *xrange[i + pixels_per_word : i + pixels_per_word + pixels_per_word],

--- a/n64img/iter.py
+++ b/n64img/iter.py
@@ -3,12 +3,16 @@ from math import ceil
 from typing import Iterable, Tuple
 
 
+WORD_SIZE = 4  # bytes
+
+
 def iter_image_indexes(
     width: int,
     height: int,
     bytes_per_pixel: float = 1,
     flip_h: bool = False,
     flip_v: bool = False,
+    swap_words: bool = False,
 ) -> Iterable[Tuple[int, int, int]]:
     w = int(width * bytes_per_pixel)
     h = int(height * 1)
@@ -18,8 +22,19 @@ def iter_image_indexes(
         if flip_h
         else range(0, w, ceil(bytes_per_pixel))
     )
+
+    if swap_words:
+        xrange = list(xrange)
+        xrange_swapped = []
+        pixels_per_word = ceil(WORD_SIZE / bytes_per_pixel)
+        for i in range(0, len(xrange), pixels_per_word * 2):
+            xrange_swapped += [
+                *xrange[i + pixels_per_word : i + pixels_per_word + pixels_per_word],
+                *xrange[i : i + pixels_per_word],
+            ]
+
     yrange = range(h - 1, -1, -1) if flip_v else range(0, h, 1)
 
-    for y in yrange:
-        for x in xrange:
+    for i, y in enumerate(yrange):
+        for x in xrange_swapped if (swap_words and i % 2 == 1) else xrange:
             yield x, y, (y * w) + x

--- a/n64img/iter.py
+++ b/n64img/iter.py
@@ -3,7 +3,7 @@ from math import ceil
 from typing import Iterable, Tuple
 
 
-WORD_SIZE = 4  # bytes
+BYTES_PER_WORD: int = 4
 
 
 def iter_image_indexes(
@@ -17,14 +17,13 @@ def iter_image_indexes(
     w = int(width * bytes_per_pixel)
     h = int(height * 1)
 
-    xrange = (
+    xrange = list(
         range(w - ceil(bytes_per_pixel), -1, -ceil(bytes_per_pixel))
         if flip_h
         else range(0, w, ceil(bytes_per_pixel))
     )
 
     if swap_words:
-        xrange = list(xrange)
         xrange_swapped = []
         pixels_per_word = ceil(WORD_SIZE / bytes_per_pixel)
         for i in range(0, len(xrange), pixels_per_word * 2):


### PR DESCRIPTION
Opening as draft for comments:
- Not sure if this is the best place to be making the changes
- Not 100% sure if the changes work (I'll try do some testing later this week).
- Not sure if the logic can't be simplified/improved, maybe a better iterator or zip or something to do the swapping.

I also ran the image.py through `black` which is why its formatted a little different - happy to undo that and recommit separately.

Example swapping a 32-pixel image:
```py
# I4 (8 pixels makes 4 bytes)
[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15] # orig xrange
[8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7] # swapped xrange

# I8 (4 pixels makes 4 bytes):
[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31]
[4, 5, 6, 7, 0, 1, 2, 3, 12, 13, 14, 15, 8, 9, 10, 11, 20, 21, 22, 23, 16, 17, 18, 19, 28, 29, 30, 31, 24, 25, 26, 27]

# RGBA16 (2 pixels makes 4 bytes):
[0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40, 42, 44, 46, 48, 50, 52, 54, 56, 58, 60, 62]
[4, 6, 0, 2, 12, 14, 8, 10, 20, 22, 16, 18, 28, 30, 24, 26, 36, 38, 32, 34, 44, 46, 40, 42, 52, 54, 48, 50, 60, 62, 56, 58]

# RGBA32 (1 pixel makes 4 bytes):
[0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 48, 52, 56, 60, 64, 68, 72, 76, 80, 84, 88, 92, 96, 100, 104, 108, 112, 116, 120, 124]
[4, 0, 12, 8, 20, 16, 28, 24, 36, 32, 44, 40, 52, 48, 60, 56, 68, 64, 76, 72, 84, 80, 92, 88, 100, 96, 108, 104, 116, 112, 124, 120]
```